### PR TITLE
Additional check for the module inserter item added on the open event…

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,8 @@
 ---------------------------------------------------------------------------------------------------
 Version: 5.2.5
-Date: ????
+Date: 27.11.2021
   Changes:
+    - Additional check for the module inserter item added on the open event. This prevents module inserter from overwriting other items from other mods allowing parallel use of them (e.g. RailSignalPlanner, Artillery Bombardment Remote)
 ---------------------------------------------------------------------------------------------------
 Version: 5.2.4
 Date: 2021-01-06

--- a/control.lua
+++ b/control.lua
@@ -45,10 +45,12 @@ local function sort_modules(entity, modules, cTable)
 end
 
 local function on_mod_item_opened(e)
-    e.player = game.get_player(e.player_index)
-    e.pdata = global._pdata[e.player_index]
-    if not e.pdata.gui_open then
-        mi_gui.open(e)
+    if e.item.name == "module-inserter" then
+        e.player = game.get_player(e.player_index)
+        e.pdata = global._pdata[e.player_index]
+        if not e.pdata.gui_open then
+           mi_gui.open(e)
+        end
     end
 end
 event.on_mod_item_opened(on_mod_item_opened)


### PR DESCRIPTION
…. This prevents module inserter from overwriting other items from other mods allowing parallel use of them (e.g. RailSignalPlanner, Artillery Bombardment Remote)